### PR TITLE
Remove map and array types

### DIFF
--- a/type_system.md
+++ b/type_system.md
@@ -96,7 +96,7 @@ type Foo = Bar
 
 ## Special types
 
-#### Error types
+### Error types
 
 ```
 type Error
@@ -104,9 +104,7 @@ type Error
   )
 ```
 
-##### ! unary operator
-
-###### Semantics
+#### ! unary operator
 
 ```
 ! : (a -> b -> ... -> c) -> a | Error -> b | Error -> ... -> c | Error

--- a/type_system.md
+++ b/type_system.md
@@ -122,15 +122,13 @@ type Error
 
 ## Expressions
 
-### Conditionals
-
-#### If expressions
+### If expressions
 
 ```
 if True then 42 else 13
 ```
 
-#### Case expressions
+### Case expressions
 
 ```
 case x = expression

--- a/type_system.md
+++ b/type_system.md
@@ -31,48 +31,22 @@ None
 "string"
 ```
 
-### Collections
-
-#### Arrays
-
-```
-Array a
-```
-
-##### Operations
-
-```
-array @ 0
-array @ Range.new 0 42
-[ ...array, 42 ]
-[ 42, ...array ]
-```
-
-#### Maps
-
-```
-Map a b
-```
-
-##### Operations
-
-```
-map @ "foo"
-{ ...map, "foo" = "bar" }
-```
-
-#### Streams
+### Streams
 
 ```
 Stream a
 ```
 
-##### Operations
+#### Operations
+
+- Evaluation of elements are always delayed.
 
 ```
-stream @ 0
-stream @ Range.new 0 42
-stream << x
+stream @ 1
+stream @ Range.new 1 42
+[ ...stream, 42 ]
+[ 42, ...stream ]
+[ x for x in stream if test x ]
 ```
 
 ### Top types
@@ -163,13 +137,4 @@ case x = expression
   Person => ...
   Number => ...
   Boolean | None => ...
-```
-
-### Iteration
-
-#### Comprehension
-
-```
-[ x for x in array if isEven x ]
-{ k = v for k, v in map if isEven x }
 ```

--- a/type_system.md
+++ b/type_system.md
@@ -22,7 +22,7 @@ True
 None
 42
 -42
-"string"
+"String"
 ```
 
 ### Functions

--- a/type_system.md
+++ b/type_system.md
@@ -41,7 +41,7 @@ Stream a
 
 #### Operations
 
-- Elements are always evaluated lazily.
+- Elements are evaluated lazily.
 
 ```
 stream @ 1

--- a/type_system.md
+++ b/type_system.md
@@ -96,14 +96,6 @@ type Foo = Bar
 
 ## Special types
 
-### Result types
-
-```
-type Result =
-    Foo
-  | Error
-```
-
 #### Error types
 
 ```
@@ -112,9 +104,9 @@ type Error
   )
 ```
 
-#### ! unary operator
+##### ! unary operator
 
-##### Semantics
+###### Semantics
 
 ```
 ! : (a -> b -> ... -> c) -> a | Error -> b | Error -> ... -> c | Error

--- a/type_system.md
+++ b/type_system.md
@@ -53,7 +53,7 @@ stream @ Range.new 1 42
 
 ### Records
 
-- Properties are hidden outside the modules where they are defined.
+- Elements are hidden outside the modules where they are defined.
 
 ```
 type Person (

--- a/type_system.md
+++ b/type_system.md
@@ -33,6 +33,8 @@ a -> b
 
 ### Streams
 
+- Lazy lists
+
 ```
 Stream a
 ```

--- a/type_system.md
+++ b/type_system.md
@@ -41,7 +41,7 @@ Stream a
 
 #### Operations
 
-- Evaluation of elements are always delayed.
+- Elements are always evaluated lazily.
 
 ```
 stream @ 1

--- a/type_system.md
+++ b/type_system.md
@@ -3,13 +3,7 @@
 - Nominal typing
 - Restricted polymorphism
 
-## Built-in types
-
-### Functions
-
-```
-a -> b
-```
+## Types
 
 ### Primitives
 
@@ -31,6 +25,12 @@ None
 "string"
 ```
 
+### Functions
+
+```
+a -> b
+```
+
 ### Streams
 
 ```
@@ -49,23 +49,15 @@ stream @ Range.new 1 42
 [ x for x in stream if test x ]
 ```
 
-### Top types
-
-```
-Any
-```
-
-## User-defined types
-
-### Record types
+### Records
 
 - Properties are hidden outside the modules where they are defined.
 
 ```
-type Person
-  ( name : String
-  , age : Number
-  )
+type Person (
+  name : String,
+  age : Number,
+)
 ```
 
 #### Element-less records
@@ -82,16 +74,16 @@ Person ( name = "foo", age = 42 )
 Person ( ...person, name = "bar" )
 ```
 
-### Union types
+### Unions
 
 ```
 Foo | Bar | Baz
 ```
 
-### Type alias
+### Any
 
 ```
-type Foo = Bar
+Any
 ```
 
 ## Special types
@@ -125,4 +117,12 @@ case x = expression
   Person => ...
   Number => ...
   Boolean | None => ...
+```
+
+## Others
+
+### Type alias
+
+```
+type Foo = Bar
 ```

--- a/type_system.md
+++ b/type_system.md
@@ -93,9 +93,9 @@ Any
 ### Error types
 
 ```
-type Error
-  ( context : Any
-  )
+type Error (
+  context : Any,
+)
 ```
 
 #### ! unary operator


### PR DESCRIPTION
This PR removes the `Array` and `Map` types.

In functional programming languages, list types or something equivalent provide following features.

- The syntax for variadic-length repetition of values
- Data structure for variadic-length repetitive values